### PR TITLE
Fixed compiling in Linux.

### DIFF
--- a/bootstrap/src/main.c
+++ b/bootstrap/src/main.c
@@ -7,6 +7,10 @@
  *   nerd parse <file.nerd>                  Parse and dump AST
  */
 
+#ifdef __linux__
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
When building for Linux, compilation fails with:
```
error: implicit declaration of function 'readlink' [-Wimplicit-function-declaration]
```

This is because `readlink` is a POSIX function that requires defining `_POSIX_C_SOURCE` before including any headers.

This change adds an `#ifdef` check for Linux and sets `_POSIX_C_SOURCE` to `200809L`, enabling the usage of `readlink` and allowing the build to succeed.